### PR TITLE
fix: 403s on action-gh-release creating release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@
 # and put the release notes into the commit message for the tag.
 name: Release
 
+# yamllint disable-line rule:truthy
 on:
   push:
     tags:
@@ -11,6 +12,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      # 403s on release: https://github.com/softprops/action-gh-release/issues/236#issue-1258868166
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Per https://github.com/softprops/action-gh-release/issues/236 we add a permission to enable the `action-gh-release` to create a release object for the repo.