### PR TITLE
ci: make prettier not fight with docs:update

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+docs/repositories.md
+docs/rules.md
+docs/toolchain.md


### PR DESCRIPTION
This PR causes `prettier` (run via pre-commit) to ignore the files generated by a `bazel run docs:update` since prettier's changes during commit would fail a diff-check against generated files during CI.

Failed diff-checks being no fun, let's just take that off prettier's radar.

