### PR TITLE
ci: activate renovateBot

### DIFF
--- a/.github/renovate-regex.json
+++ b/.github/renovate-regex.json
@@ -1,0 +1,8 @@
+{
+  "jq": {
+    "renovate_datasource": "github-tags",
+    "renovate_depname": "jqlang/jq",
+    "renovate_versioning": "regex:^jq-(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?$",
+    "version": "jq-1.6"
+  }
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "labels": ["dependencies"]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+
+  "packageRules": [
+    {
+      "enabled": true,
+      "matchManagers": ["regex"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["renovate-regex.json$"],
+      "matchStrings": [
+        "\"renovate_datasource\": \"(?<datasource>.*?)\",\\s    \"renovate_depname\": \"(?<depName>.*?)\",\\s(    \"renovate_versioning\": \"(?<versioning>.*?)\",\\s)?(    \"sha256\": \"(?<currentDigest>.*?)\",\\s)?    \"version\": \"(?<currentValue>.*?)\""
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
+    }
+  ],
+  "reviewers": ["@chickenandpork"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,5 +20,5 @@
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
     }
   ],
-  "reviewers": ["@bazel_rules_jq-admins"]
+  "reviewers": ["@bazel_rules_jq-maintainers"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,5 +20,5 @@
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
     }
   ],
-  "reviewers": ["@chickenandpork"]
+  "reviewers": ["@bazel_rules_jq-admins"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 docs/repositories.md
 docs/rules.md
 docs/toolchain.md
+# whitespsce matters: a regex is used to parse and automatically update this json
+.github/renovate-regex.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 docs/repositories.md
 docs/rules.md
 docs/toolchain.md
-# whitespsce matters: a regex is used to parse and automatically update this json
+# whitespace matters: a regex is used to parse and automatically update this json
 .github/renovate-regex.json


### PR DESCRIPTION
This PR activates the Renovate tool (a more capable Dependabot) to detect outdated dependencies and propose updates via PR; the PR then goes through standard build checks before being reviewed and accepted by a team member.

Renovate Overview for this repo would be at:

https://developer.mend.io/github/jqlang/bazel_rules_jq